### PR TITLE
Added missing QueueArn to full list of attributes, added test for it

### DIFF
--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
@@ -420,6 +420,7 @@ class AmazonJavaSdkTestSuite extends FunSuite with MustMatchers with BeforeAndAf
     attributes must contain key (visibilityTimeoutAttribute)
     attributes must contain key (delaySecondsAttribute)
     attributes must contain key (receiveMessageWaitTimeSecondsAttribute)
+    attributes must contain key ("QueueArn")
   }
 
   test("should return proper queue statistics after receiving, deleting a message") {

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -27,7 +27,8 @@ trait QueueAttributesDirectives { this: ElasticMQDirectives with AttributesModul
         ApproximateNumberOfMessagesNotVisibleAttribute ::
         ApproximateNumberOfMessagesDelayedAttribute ::
         CreatedTimestampAttribute ::
-        LastModifiedTimestampAttribute :: Nil)
+        LastModifiedTimestampAttribute :: 
+        QueueArnAttribute :: Nil)
   }
 
   val getQueueAttributes = {


### PR DESCRIPTION
Currently `QueueArn` is returned only if you specifically as for it in the `GetAttributes` request.

This PR adds it to the list of all attributes.

Sorry I've missed that in my previous PR :crying_cat_face: 