### PR TITLE
Ignore unsupported attributes that are supported by SQS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 target
 out
 project/boot
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .idea
 *.iml
 *.ipr
+.classpath
+.settings
+.project
 target
 out
 project/boot

--- a/README.md
+++ b/README.md
@@ -193,6 +193,25 @@ Note that both the client and the server were on the same machine.
 
 Test class: `org.elasticmq.performance.LocalPerformanceTest`.
 
+Building, running, and packaging
+--------------------------------
+
+To build and run with debug (this will listen for a remote debugger on port 5005):  
+```
+~/workspace/elasticmq $ sbt jvm-debug 5005  
+> project elasticmq-server
+> run
+```
+
+To build a jar-with-dependencies:  
+```
+~/workspace/elasticmq $ sbt 
+> project elasticmq-server
+> assembly
+```
+
+
+
 Technology
 ----------
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
 
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
+
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
-
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -105,7 +105,7 @@ trait QueueAttributesDirectives { this: ElasticMQDirectives with AttributesModul
               case ReceiveMessageWaitTimeSecondsAttribute => {
                 queueActor ? UpdateQueueReceiveMessageWait(Duration.standardSeconds(attributeValue.toLong))
               }
-              case a if UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(attributeName) => {
+              case attributeName if UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(attributeName) => {
                 logger.warn("Ignored attribute \"" + attributeName + "\" (supported by SQS but not ElasticMQ)")
                 Future()
               }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -107,7 +107,8 @@ trait QueueAttributesDirectives { this: ElasticMQDirectives with AttributesModul
               }
               case _ => { // I'm sure there's a more idiomatic scala way to do this.
                 if (UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(attributeName)){
-                  Future(Nil) // Don't error
+                  logger.warn("Ignored attribute \"" + attributeName + "\" (supported by SQS but not ElasticMQ)")
+                  Future() // Don't error; how to log?
                 } else {
                   Future(throw new SQSException("InvalidAttributeName"))
                 }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -105,14 +105,11 @@ trait QueueAttributesDirectives { this: ElasticMQDirectives with AttributesModul
               case ReceiveMessageWaitTimeSecondsAttribute => {
                 queueActor ? UpdateQueueReceiveMessageWait(Duration.standardSeconds(attributeValue.toLong))
               }
-              case _ => { // I'm sure there's a more idiomatic scala way to do this.
-                if (UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(attributeName)){
-                  logger.warn("Ignored attribute \"" + attributeName + "\" (supported by SQS but not ElasticMQ)")
-                  Future() // Don't error; how to log?
-                } else {
-                  Future(throw new SQSException("InvalidAttributeName"))
-                }
+              case a if UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(attributeName) => {
+                logger.warn("Ignored attribute \"" + attributeName + "\" (supported by SQS but not ElasticMQ)")
+                Future()
               }
+              case _ => Future(throw new SQSException("InvalidAttributeName"))
             }
           })
 

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -18,7 +18,7 @@ trait QueueAttributesDirectives { this: ElasticMQDirectives with AttributesModul
   object UnsupportedAttributeNames {
     val PolicyAttribute = "Policy"
     val MaximumMessageSizeAttribute = "MaximumMessageSize"
-    val MessageRetentionPeriodAttribute = "MessageRetentionPeriodAttribute"
+    val MessageRetentionPeriodAttribute = "MessageRetentionPeriod"
     val RedrivePolicyAttribute = "RedrivePolicy"
     
     val AllUnsupportedAttributeNames = PolicyAttribute :: MaximumMessageSizeAttribute :: 
@@ -105,10 +105,13 @@ trait QueueAttributesDirectives { this: ElasticMQDirectives with AttributesModul
               case ReceiveMessageWaitTimeSecondsAttribute => {
                 queueActor ? UpdateQueueReceiveMessageWait(Duration.standardSeconds(attributeValue.toLong))
               }
-              case unsupported if UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(unsupported) => {
-                Future(Nil) // Don't error
+              case _ => { // I'm sure there's a more idiomatic scala way to do this.
+                if (UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(attributeName)){
+                  Future(Nil) // Don't error
+                } else {
+                  Future(throw new SQSException("InvalidAttributeName"))
+                }
               }
-              case _ => Future(throw new SQSException("InvalidAttributeName"))
             }
           })
 

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -14,6 +14,16 @@ trait QueueAttributesDirectives { this: ElasticMQDirectives with AttributesModul
     val AllWriteableAttributeNames = VisibilityTimeoutParameter :: DelaySecondsAttribute ::
       ReceiveMessageWaitTimeSecondsAttribute :: Nil
   }
+  
+  object UnsupportedAttributeNames {
+    val PolicyAttribute = "Policy"
+    val MaximumMessageSizeAttribute = "MaximumMessageSize"
+    val MessageRetentionPeriodAttribute = "MessageRetentionPeriodAttribute"
+    val RedrivePolicyAttribute = "RedrivePolicy"
+    
+    val AllUnsupportedAttributeNames = PolicyAttribute :: MaximumMessageSizeAttribute :: 
+      MessageRetentionPeriodAttribute :: RedrivePolicyAttribute :: Nil
+  }
 
   object QueueReadableAttributeNames {
     val ApproximateNumberOfMessagesAttribute = "ApproximateNumberOfMessages"
@@ -94,6 +104,9 @@ trait QueueAttributesDirectives { this: ElasticMQDirectives with AttributesModul
               }
               case ReceiveMessageWaitTimeSecondsAttribute => {
                 queueActor ? UpdateQueueReceiveMessageWait(Duration.standardSeconds(attributeValue.toLong))
+              }
+              case unsupported if UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(unsupported) => {
+                Future(Nil) // Don't error
               }
               case _ => Future(throw new SQSException("InvalidAttributeName"))
             }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -105,8 +105,8 @@ trait QueueAttributesDirectives { this: ElasticMQDirectives with AttributesModul
               case ReceiveMessageWaitTimeSecondsAttribute => {
                 queueActor ? UpdateQueueReceiveMessageWait(Duration.standardSeconds(attributeValue.toLong))
               }
-              case attributeName if UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(attributeName) => {
-                logger.warn("Ignored attribute \"" + attributeName + "\" (supported by SQS but not ElasticMQ)")
+              case attr if UnsupportedAttributeNames.AllUnsupportedAttributeNames.contains(attr) => {
+                logger.warn("Ignored attribute \"" + attr + "\" (supported by SQS but not ElasticMQ)")
                 Future()
               }
               case _ => Future(throw new SQSException("InvalidAttributeName"))


### PR DESCRIPTION
I'm sure there's a more idiomatic scala way to do what I'm doing, and it probably deserves some kind of flag for whether to enable it or not, but basically I created a list of all the unsupported-by-elasticmq-but-supported-by-SQS queue attributes, and before rejecting an update for an unsupported attribute we check if the attribute is valid in SQS, and then log+ignore it.