### PR TITLE
Allow 256KB akka URI to match Amazon SQS

### DIFF
--- a/rest/rest-sqs/src/main/resources/application.conf
+++ b/rest/rest-sqs/src/main/resources/application.conf
@@ -13,3 +13,5 @@ akka {
 # TODO - not present in akka http?
 akka.http.server.request-timeout = 21 s
 
+# Amazon SQS allows 256KB message payloads
+akka.http.server.parsing.max-uri-length = 256k


### PR DESCRIPTION
We found in testing that some of our messages that worked on Amazon SQS failed to ElasticMQ, with a 414 exception, and an URI length error in the logs.

In order to match Amazon SQS specifications, I'm setting akka's max-uri-length to 256K.