### PR TITLE
Update Akka to 2.4. + sbt, aws, and others.

### DIFF
--- a/performance-tests/src/test/scala/org/elasticmq/performance/LocalPerformanceTest.scala
+++ b/performance-tests/src/test/scala/org/elasticmq/performance/LocalPerformanceTest.scala
@@ -1,17 +1,21 @@
 package org.elasticmq.performance
 
+import java.util.concurrent.TimeUnit
+
 import com.amazonaws.services.sqs.AmazonSQSClient
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.sqs.model.{CreateQueueRequest, DeleteMessageRequest, ReceiveMessageRequest, SendMessageRequest}
 import org.elasticmq.rest.sqs.{SQSRestServer, SQSRestServerBuilder}
 import org.elasticmq.test._
+
 import scala.collection.JavaConversions._
-import akka.actor.{Props, ActorSystem, ActorRef}
+import akka.actor.{ActorRef, ActorSystem, Props}
 import org.elasticmq.actor.QueueManagerActor
 import org.elasticmq.util.NowProvider
 import org.elasticmq.actor.reply._
 import org.elasticmq.msg._
 import org.elasticmq._
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.joda.time.DateTime
@@ -141,8 +145,7 @@ object LocalPerformanceTest extends App {
     }
 
     def stop() {
-      actorSystem.shutdown()
-      actorSystem.awaitTermination()
+      actorSystem.terminate()
     }
 
     def sendMessage(m: String)
@@ -153,7 +156,7 @@ object LocalPerformanceTest extends App {
   trait MQWithQueueManagerActor extends MQ {
     private var currentQueue: ActorRef = _
 
-    implicit val timeout = Timeout(10000L)
+    implicit val timeout = Timeout(10000L, TimeUnit.MILLISECONDS)
 
     override def start() = {
       val queueManagerActor = super.start()

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object BuildSettings {
     version       := "0.9.3",
     scalaVersion  := "2.11.8",
 
-    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
+    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
 
     // Sonatype OSS deployment
     publishTo := {
@@ -44,9 +44,9 @@ object BuildSettings {
 object Dependencies {
   val jodaTime      = "joda-time"                 % "joda-time"             % "2.9.3"
   val jodaConvert   = "org.joda"                  % "joda-convert"          % "1.8.1"
-  val config        = "com.typesafe"              % "config"                % "1.2.1"
+  val config        = "com.typesafe"              % "config"                % "1.3.0"
 
-  val scalalogging  = "com.typesafe.scala-logging" %% "scala-logging"       % "3.1.0"
+  val scalalogging  = "com.typesafe.scala-logging" %% "scala-logging"       % "3.5.0"
   val logback       = "ch.qos.logback"            % "logback-classic"       % "1.1.7"
   val jclOverSlf4j  = "org.slf4j"                 % "jcl-over-slf4j"        % "1.7.21" // needed form amazon java sdk
 
@@ -54,14 +54,14 @@ object Dependencies {
   val mockito       = "org.mockito"               % "mockito-core"          % "1.10.19"
   val awaitility    = "com.jayway.awaitility"     % "awaitility-scala"      % "1.7.0"
 
-  val amazonJavaSdk = "com.amazonaws"             % "aws-java-sdk"          % "1.10.69" exclude ("commons-logging", "commons-logging")
+  val amazonJavaSdk = "com.amazonaws"             % "aws-java-sdk"          % "1.11.25" exclude ("commons-logging", "commons-logging")
 
-  val akka2Version  = "2.3.15"
+  val akka2Version  = "2.4.10"
   val akka2Actor    = "com.typesafe.akka" %% "akka-actor"           % akka2Version
   val akka2Slf4j    = "com.typesafe.akka" %% "akka-slf4j"           % akka2Version
   val akka2Testkit  = "com.typesafe.akka" %% "akka-testkit"         % akka2Version % "test"
-  val akka2Http     = "com.typesafe.akka" %% "akka-http-experimental" % "2.0.4"
-  val akka2HttpTestkit = "com.typesafe.akka" %% "akka-http-testkit-experimental" % "2.0.4" % "test"
+  val akka2Http     = "com.typesafe.akka" %% "akka-http-experimental" % akka2Version
+  val akka2HttpTestkit = "com.typesafe.akka" %% "akka-http-testkit-experimental" % "2.4.2-RC3" % "test"
 
   val scalaAsync    = "org.scala-lang.modules" % "scala-async_2.11" % "0.9.5"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.12


### PR DESCRIPTION
Various dependencies updated.
Fixes https://github.com/adamw/elasticmq/issues/77

`Build.scala` is deprecated in favour of `build.sbt`, so maybe I'll try to fix that later.

Thank you @adamw for this cool project.