### PR TITLE
md5Digest(): explicitly provide getBytes() encoding

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
@@ -246,7 +246,7 @@ object MD5Util {
   def md5Digest(s: String) = {
     val md5 = MessageDigest.getInstance("MD5")
     md5.reset()
-    md5.update(s.getBytes)
+    md5.update(s.getBytes("UTF-8"))
     md5.digest().map(0xFF & _).map { "%02x".format(_) }.foldLeft(""){_ + _}
   }
 


### PR DESCRIPTION
If encoding not provided, String.getBytes() uses system encoding to convert string into array of bytes. If system encoding is not set or it is not unicode, then unicode symbols may be lost/altered (we experienced this in our docker container). As a result, md5 checksum will be wrong (I'm not sure if the message itself gets corrupted). This should fix #13.