### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ queues {
         delay = 5 seconds
         receiveMessageWait = 0 seconds
         deadLettersQueue {
-            name = "myDLQ"
+            name = "queue1-dead-letters"
             maxReceiveCount = 3 // from 1 to 1000
     	}
     }
-    queue2 { }
+    queue1-dead-letters { }
 }
 ````
 


### PR DESCRIPTION
Make it more obvious that you need to manually specify the dead letters queue in the `queues` section.

(It took me ages to figure out that elasticmq does not create the dead letters queue for you automatically.)