### PR TITLE
fix typo in example configuration for deadletter queues in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ queues {
         defaultVisibilityTimeout = 10 seconds
         delay = 5 seconds
         receiveMessageWait = 0 seconds
-        deadLettersQueue {
+        deadLetterQueue {
             name = "queue1-dead-letters"
             maxReceiveCount = 3 // from 1 to 1000
     	}
@@ -130,7 +130,7 @@ queues {
 }
 ````
 
-All attributes are optional (except `name` and `maxReceiveCount` when a `deadLettersQueue` is defined).
+All attributes are optional (except `name` and `maxReceiveCount` when a `deadLetterQueue` is defined).
 
 Starting an embedded ElasticMQ server with an SQS interface
 -----------------------------------------------------------


### PR DESCRIPTION
Couldn't figure out why the queues with deadletter queue config in custom.conf file weren't being created, after following the example in README. Turns out there was a typo.