### PR TITLE
Fix random queue creation order.

### DIFF
--- a/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
+++ b/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
@@ -21,7 +21,7 @@ class QueueManagerActor(nowProvider: NowProvider) extends ReplyingActor with Log
         logger.debug(s"Cannot create queue, as it already exists: $queueData")
         Left(new QueueAlreadyExists(queueData.name))
       } else if (!queueData.deadLettersQueue.forall(dlq => queues.contains(dlq.name))) {
-        logger.debug(s"Cannot create queue, its dead letters queue doesnt exists: $queueData")
+        logger.error(s"Cannot create queue, its dead letters queue doesn't exists: $queueData")
         Left(new QueueDoesNotExist(queueData.deadLettersQueue.get.name))
       } else {
         logger.info(s"Creating queue $queueData")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,6 +57,8 @@ object Dependencies {
 
   val amazonJavaSdk = "com.amazonaws"             % "aws-java-sdk"          % "1.11.84" exclude ("commons-logging", "commons-logging")
 
+  val scalaGraph    = "org.scala-graph"           %% "graph-core"           % "1.11.5"
+
   val akkaVersion      = "2.5.0"
   val akkaHttpVersion  = "10.0.5"
   val akka2Actor       = "com.typesafe.akka" %% "akka-actor"           % akkaVersion
@@ -124,7 +126,7 @@ object ElasticMQBuild extends Build {
     "elasticmq-server",
     file("server"),
     settings = buildSettings ++ CustomTasks.generateVersionFileSettings ++ Seq(
-      libraryDependencies ++= Seq(logback, config),
+      libraryDependencies ++= Seq(logback, config, scalaGraph),
       mainClass in assembly := Some("org.elasticmq.server.Main")
     )
   ) dependsOn(core, restSqs, commonTest % "test")

--- a/server/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
+++ b/server/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
@@ -10,8 +10,12 @@ import org.elasticmq.util.{Logging, NowProvider}
 import org.elasticmq.{DeadLettersQueueData, MillisVisibilityTimeout, QueueData}
 import org.joda.time.{DateTime, Duration}
 
+import scala.collection.mutable.ListBuffer
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration.Inf
+import scalax.collection.Graph
+import scalax.collection.GraphPredef._
+import scalax.collection.GraphEdge._
 
 class ElasticMQServer(config: ElasticMQServerConfig) extends Logging {
   val actorSystem = ActorSystem("elasticmq")
@@ -60,11 +64,10 @@ class ElasticMQServer(config: ElasticMQServerConfig) extends Logging {
       Timeout(5.seconds)
     }
 
-    val futures = config.createQueues.map { cq =>
-      queueManagerActor ? CreateQueue(configToParams(cq, new DateTime))
+    sortCreateQueues(config.createQueues).map { cq =>
+      val f = queueManagerActor ? CreateQueue(configToParams(cq, new DateTime))
+      Await.result(f, timeout.duration)
     }
-
-    futures.foreach { f => Await.result(f, timeout.duration) }
   }
 
   private def configToParams(cq: config.CreateQueue, now: DateTime): QueueData = {
@@ -79,5 +82,41 @@ class ElasticMQServer(config: ElasticMQServerConfig) extends Logging {
       lastModified = now,
       deadLettersQueue = cq.deadLettersQueue.map(dlq => DeadLettersQueueData(dlq.name, dlq.maxReceiveCount))
     )
+  }
+
+  private def sortCreateQueues(cqs: List[config.CreateQueue]): List[config.CreateQueue] = {
+    val nodes = cqs
+    val edges = createDeadLetterQueueEdges(nodes)
+    val sorted = Graph.from(nodes, edges).topologicalSort()
+
+    if (sorted.isLeft) {
+      throw new IllegalArgumentException(s"Circular queue graph, check ${sorted.left.get.value.name}")
+    }
+    sorted.right.get.toList.reverse.map { node => node.value }
+  }
+
+  private def createDeadLetterQueueEdges(nodes: List[config.CreateQueue]): List[DiEdge[config.CreateQueue]] = {
+    var edges = new ListBuffer[DiEdge[config.CreateQueue]]()
+
+    var queueMap = Map[String, config.CreateQueue]()
+    nodes.foreach { cq =>
+      queueMap += (cq.name -> cq)
+    }
+
+    nodes.foreach { cq =>
+      if (cq.deadLettersQueue.nonEmpty) {
+        val dlcqName = cq.deadLettersQueue.get.name
+        val dlcq = queueMap.get(dlcqName)
+
+        if (dlcq.isEmpty) {
+          logger.error("Dead letter queue {} not found", dlcqName)
+        }
+        else {
+          edges += cq ~> dlcq.get
+        }
+      }
+    }
+
+    edges.toList
   }
 }

--- a/server/src/main/scala/org/elasticmq/server/QueueSorter.scala
+++ b/server/src/main/scala/org/elasticmq/server/QueueSorter.scala
@@ -1,0 +1,57 @@
+package org.elasticmq.server
+
+import org.elasticmq.server.config.CreateQueue
+import org.elasticmq.util.Logging
+
+import scala.collection.mutable.ListBuffer
+import scalax.collection.Graph
+import scalax.collection.GraphPredef._
+import scalax.collection.GraphEdge._
+
+object QueueSorter extends Logging {
+  /**
+    * Reverse topologically sort CreateQueue collection so that dead letter queues are created first
+    * @param cqs
+    * @return
+    */
+  def sortCreateQueues(cqs: List[CreateQueue]): List[CreateQueue] = {
+    val nodes = cqs
+    val edges = createDeadLetterQueueEdges(nodes)
+    val sorted = Graph.from(nodes, edges).topologicalSort()
+
+    // There's a cycle somewhere in the graph
+    if (sorted.isLeft) {
+      throw new IllegalArgumentException(s"Circular queue graph, check ${sorted.left.get.value.name}")
+    }
+
+    sorted.right.get.toList.reverse.map { node => node.value }
+  }
+
+  private def createDeadLetterQueueEdges(nodes: List[CreateQueue]): List[DiEdge[CreateQueue]] = {
+    var edges = new ListBuffer[DiEdge[CreateQueue]]()
+
+    // create map to look up queues by name
+    var queueMap = Map[String, CreateQueue]()
+    nodes.foreach { cq =>
+      queueMap += (cq.name -> cq)
+    }
+
+    // create directed edges from queue -> dead letter queue
+    nodes.foreach { cq =>
+      if (cq.deadLettersQueue.nonEmpty) {
+        val dlcqName = cq.deadLettersQueue.get.name
+        val dlcq = queueMap.get(dlcqName)
+
+        if (dlcq.isEmpty) {
+          logger.error("Dead letter queue {} not found", dlcqName)
+        }
+        else {
+          edges += cq ~> dlcq.get
+        }
+      }
+    }
+
+    edges.toList
+  }
+
+}

--- a/server/src/main/scala/org/elasticmq/server/config/CreateQueue.scala
+++ b/server/src/main/scala/org/elasticmq/server/config/CreateQueue.scala
@@ -1,0 +1,8 @@
+package org.elasticmq.server.config
+
+case class CreateQueue(name: String,
+                       defaultVisibilityTimeoutSeconds: Option[Long],
+                       delaySeconds: Option[Long],
+                       receiveMessageWaitSeconds: Option[Long],
+                       deadLettersQueue: Option[DeadLettersQueue])
+

--- a/server/src/main/scala/org/elasticmq/server/config/DeadLettersQueue.scala
+++ b/server/src/main/scala/org/elasticmq/server/config/DeadLettersQueue.scala
@@ -1,0 +1,4 @@
+package org.elasticmq.server.config
+
+case class DeadLettersQueue(name: String, maxReceiveCount: Int)
+

--- a/server/src/test/scala/org/elasticmq/server/QueueSorterTest.scala
+++ b/server/src/test/scala/org/elasticmq/server/QueueSorterTest.scala
@@ -1,0 +1,56 @@
+package org.elasticmq.server
+
+import org.elasticmq.server.config.{CreateQueue, DeadLettersQueue}
+import org.scalatest.{FunSuite, Matchers}
+
+class QueueSorterTest extends FunSuite with Matchers {
+  test("sorts an empty list") {
+    val sortedQueues = QueueSorter.sortCreateQueues(List())
+    sortedQueues should have size(0)
+  }
+
+  test("sorts one queue") {
+    val sortedQueues = QueueSorter.sortCreateQueues(List(CreateQueue("queue1", None, None, None, None)))
+    sortedQueues should have size(1)
+    sortedQueues.head.name should be ("queue1")
+  }
+
+  test("sorts queue and dead letters queue") {
+    val sortedQueues = QueueSorter.sortCreateQueues(List(
+      CreateQueue("queue1", None, None, None, Some(DeadLettersQueue("deadletters", 1))),
+      CreateQueue("deadletters", None, None, None, None)
+    ))
+    sortedQueues should have size(2)
+    sortedQueues.head.name should be ("deadletters")
+  }
+
+  test("throws exception for circular graphs") {
+    an [IllegalArgumentException] should be thrownBy QueueSorter.sortCreateQueues(List(
+      CreateQueue("queue1", None, None, None, Some(DeadLettersQueue("deadletters", 1))),
+      CreateQueue("deadletters", None, None, None, Some(DeadLettersQueue("queue1", 1)))
+    ))
+  }
+
+  test("sorts two queues that use the same dead letters queue") {
+    val sortedQueues = QueueSorter.sortCreateQueues(List(
+      CreateQueue("queue1", None, None, None, Some(DeadLettersQueue("deadletters", 1))),
+      CreateQueue("deadletters", None, None, None, None),
+      CreateQueue("queue2", None, None, None, Some(DeadLettersQueue("deadletters", 1)))
+    ))
+    sortedQueues should have size(3)
+    sortedQueues.head.name should be ("deadletters")
+    sortedQueues.tail.map(_.name) should contain only ("queue1", "queue2")
+  }
+
+  test("sorts chained dead letters queues") {
+    val sortedQueues = QueueSorter.sortCreateQueues(List(
+      CreateQueue("queue1", None, None, None, Some(DeadLettersQueue("deadletters1", 1))),
+      CreateQueue("deadletters1", None, None, None, Some(DeadLettersQueue("deadletters2", 1))),
+      CreateQueue("deadletters2", None, None, None, None),
+      CreateQueue("queue2", None, None, None, Some(DeadLettersQueue("deadletters1", 1)))
+    ))
+    sortedQueues should have size(4)
+    sortedQueues.take(2).map(_.name) should contain inOrderOnly ("deadletters2", "deadletters1")
+    sortedQueues.drop(2).map(_.name) should contain only ("queue1", "queue2")
+  }
+}


### PR DESCRIPTION
Synchronously create queues in a topologically sorted order based on
their dependency graph.

Should fix #102 

If you decide to go a different direction to solve the problem, that is fine by me.  No pressure to accept it.  Also, I'm a total Scala newbie, so feedback is welcome.