### PR TITLE
Fix for MD5OfMessageAttributes when MessageAttributes is empty. This closes #114

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
@@ -88,7 +88,7 @@ trait ReceiveMessageDirectives { this: ElasticMQDirectives with AttributesModule
                   <MD5OfBody>{md5Digest(msg.content)}</MD5OfBody>
                   <Body>{XmlUtil.convertTexWithCRToNodeSeq(msg.content)}</Body>
                   {attributesToXmlConverter.convert(calculateAttributeValues(msg))}
-                  <MD5OfMessageAttributes>{md5AttributeDigest(filteredMessageAttributes)}</MD5OfMessageAttributes>
+                  {if (!filteredMessageAttributes.isEmpty) <MD5OfMessageAttributes>{md5AttributeDigest(filteredMessageAttributes)}</MD5OfMessageAttributes>}
                   {messageAttributesToXmlConverter.convert(filteredMessageAttributes.toList)}
                 </Message> }}
               </ReceiveMessageResult>


### PR DESCRIPTION
Hey!
Thank you for this awesome tool!
This PR solves https://github.com/adamw/elasticmq/issues/114

This is my first contribution to Scala project (in fact, first to Java similar thingy too) so, good hints are honestly welcomed.