### PR TITLE
Add coverage instrumentation and few simple tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ tl;dr
 * [Amazon SQS](http://aws.amazon.com/sqs/)-compatible interface
 * fully asynchronous implementation, no blocking calls
 
-Created and maintained by 
+Created and maintained by
 [<img src="https://softwaremill.com/images/header-main-logo.svg" alt="SoftwareMill logo" height="25">](https://softwaremill.com)
 
 Summary
@@ -61,7 +61,7 @@ The config file may contain any configuration for Akka and ElasticMQ. Current El
 ````
 include classpath("application.conf")
 
-// What is the outside visible address of this ElasticMQ node 
+// What is the outside visible address of this ElasticMQ node
 // Used to create the queue URL (may be different from bind address!)
 node-address {
     protocol = http
@@ -147,7 +147,7 @@ If you need to bind to a different host/port, there are configuration methods on
     server.stopAndWait()
 
 You can also set a dynamic port with a port value of `0` or by using the method `withDynamicPort`. To retrieve the port (and other configuration) when using a dynamic port value you can access the server via `waitUntilStarted` for example:
-    
+
     val server = SQSRestServerBuilder.withDynamicPort().start()
     server.waitUntilStarted().localAddress().getPort()
 
@@ -274,19 +274,46 @@ Test class: `org.elasticmq.performance.LocalPerformanceTest`.
 Building, running, and packaging
 --------------------------------
 
-To build and run with debug (this will listen for a remote debugger on port 5005):  
+To build and run with debug (this will listen for a remote debugger on port 5005):
 ```
-~/workspace/elasticmq $ sbt -jvm-debug 5005  
+~/workspace/elasticmq $ sbt -jvm-debug 5005
 > project elasticmq-server
 > run
 ```
 
-To build a jar-with-dependencies:  
+To build a jar-with-dependencies:
 ```
 ~/workspace/elasticmq $ sbt
 > project elasticmq-server
 > assembly
 ```
+
+Tests and coverage
+------------------
+
+To run the tests:
+```
+~/workspace/elasticmq $ sbt test
+```
+
+To check the coverage reports:
+```
+~/workspace/elasticmq $ sbt
+> coverage
+> tests
+> coverageReport
+> coverageAggregate
+```
+
+Although it's mostly only the core project that is relevant for coverage testing, each project's report can be found
+in their target directory:
+
+ * core/target/scala-2.12/scoverage-report/index.html
+ * common-test/target/scala-2.12/scoverage-report/index.html
+ * rest/rest-sqs/target/scala-2.12/scoverage-report/index.html
+ * server/target/scala-2.12/scoverage-report/index.html
+
+The aggregate report can be found at target/scala-2.12/scoverage-report/index.html
 
 Technology
 ----------
@@ -380,7 +407,7 @@ Change log
 * replace Spray with Akka
 * increase message body size limits
 * provide an option to create queues on startup
-* add a special node-address setting: `*`, which uses the incoming request url to create queue urls 
+* add a special node-address setting: `*`, which uses the incoming request url to create queue urls
 
 #### Version 0.8.12 (30 Sep 2015)
 

--- a/core/src/main/scala/org/elasticmq/ElasticMQError.scala
+++ b/core/src/main/scala/org/elasticmq/ElasticMQError.scala
@@ -6,11 +6,6 @@ trait ElasticMQError {
   val message: String
 }
 
-class QueueDoesNotExist(val queueName: String) extends ElasticMQError {
-  val code = "QueueDoesNotExist"
-  val message = s"Queue does not exist: $queueName"
-}
-
 class QueueAlreadyExists(val queueName: String) extends ElasticMQError {
   val code = "QueueAlreadyExists"
   val message = s"Queue already exists: $queueName"

--- a/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
+++ b/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
@@ -5,7 +5,7 @@ import org.elasticmq.actor.queue.QueueActor
 import org.elasticmq.actor.reply._
 import org.elasticmq.msg.{CreateQueue, DeleteQueue, _}
 import org.elasticmq.util.{Logging, NowProvider}
-import org.elasticmq.{QueueAlreadyExists, QueueData, QueueDoesNotExist}
+import org.elasticmq.{QueueAlreadyExists, QueueData}
 
 import scala.reflect._
 
@@ -20,9 +20,6 @@ class QueueManagerActor(nowProvider: NowProvider) extends ReplyingActor with Log
       if (queues.contains(queueData.name)) {
         logger.debug(s"Cannot create queue, as it already exists: $queueData")
         Left(new QueueAlreadyExists(queueData.name))
-      } else if (!queueData.deadLettersQueue.forall(dlq => queues.contains(dlq.name))) {
-        logger.error(s"Cannot create queue, its dead letters queue doesn't exists: $queueData")
-        Left(new QueueDoesNotExist(queueData.deadLettersQueue.get.name))
       } else {
         logger.info(s"Creating queue $queueData")
         val actor = createQueueActor(nowProvider, queueData)

--- a/core/src/test/scala/org/elasticmq/actor/QueueActorMsgOpsTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/QueueActorMsgOpsTest.scala
@@ -257,7 +257,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
       List(receiveResult2) <- queueActor ? ReceiveMessages(DefaultVisibilityTimeout, 1, None)
     } yield {
       // Then
-      lookupResult.statistics should be (MessageStatistics(NeverReceived, 0))
+      lookupResult.statistics should be (MessageStatistics.empty)
       receiveResult1.statistics should be (MessageStatistics(OnDateTimeReceived(new DateTime(100L)), 1))
       receiveResult2.statistics should be (MessageStatistics(OnDateTimeReceived(new DateTime(110L)), 2))
     }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,6 +1,7 @@
 import sbt._
 import Keys._
 import sbtassembly.AssemblyKeys._
+import scoverage.ScoverageKeys._
 
 object BuildSettings {
   val buildSettings = Defaults.coreDefaultSettings ++ Seq (
@@ -99,7 +100,11 @@ object ElasticMQBuild extends Build {
   lazy val core: Project = Project(
     "elasticmq-core",
     file("core"),
-    settings = buildSettings ++ Seq(libraryDependencies ++= Seq(jodaTime, jodaConvert, akka2Actor, akka2Testkit) ++ common)
+    settings = buildSettings ++ Seq(
+      libraryDependencies ++= Seq(jodaTime, jodaConvert, akka2Actor, akka2Testkit) ++ common,
+      coverageMinimum := 94,
+      coverageFailOnMinimum := true
+    )
   ) dependsOn(commonTest % "test")
 
   lazy val rest: Project = Project(
@@ -128,7 +133,9 @@ object ElasticMQBuild extends Build {
     file("server"),
     settings = buildSettings ++ CustomTasks.generateVersionFileSettings ++ Seq(
       libraryDependencies ++= Seq(logback, config, scalaGraph),
-      mainClass in assembly := Some("org.elasticmq.server.Main")
+      mainClass in assembly := Some("org.elasticmq.server.Main"),
+      coverageMinimum := 52,
+      coverageFailOnMinimum := true
     )
   ) dependsOn(core, restSqs, commonTest % "test")
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -102,8 +102,7 @@ object ElasticMQBuild extends Build {
     file("core"),
     settings = buildSettings ++ Seq(
       libraryDependencies ++= Seq(jodaTime, jodaConvert, akka2Actor, akka2Testkit) ++ common,
-      coverageMinimum := 94,
-      coverageFailOnMinimum := true
+      coverageMinimum := 94
     )
   ) dependsOn(commonTest % "test")
 
@@ -134,8 +133,7 @@ object ElasticMQBuild extends Build {
     settings = buildSettings ++ CustomTasks.generateVersionFileSettings ++ Seq(
       libraryDependencies ++= Seq(logback, config, scalaGraph),
       mainClass in assembly := Some("org.elasticmq.server.Main"),
-      coverageMinimum := 52,
-      coverageFailOnMinimum := true
+      coverageMinimum := 52
     )
   ) dependsOn(core, restSqs, commonTest % "test")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
 
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")


### PR DESCRIPTION
This is a pretty simple PR that pulls in scoverage so that coverage reports can be generated after the tests have run. It's compatible with https://coveralls.io in case there's a desire to hook that up too.

For now, you can generate the reports by executing `sbt clean coverage test coverageReport`. That will instrument all the src/main/scala code and generate coverage reports for each subproject. Although it's mostly only core that's relevant, each report can be found at:
 - core/target/scala-2.12/scoverage-report/index.html
 - common-test/target/scala-2.12/scoverage-report/index.html
 - rest/rest-sqs/target/scala-2.12/scoverage-report/index.html
 - server/target/scala-2.12/scoverage-report/index.html

It's also possible to aggregate all reports by executing `sbt coverageAggregate` which will write an HTML report to target/scala-2.12/scoverage-report/index.html.

For core and the server, I've set minimum coverage thresholds so that if the coverage dips below those thresholds, `sbt coverageReport` will complain.

I'm working on adding in FIFO queue support and wanted to make sure I didn't miss anything :)

As a bonus, I've added 2 tests that bump up the coverage a bit.