### PR TITLE
Update DLQ to allow adding after queue creation and allow tagging queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ queues {
         contentBasedDeduplication = false
         copyTo = "audit-queue-name"
         moveTo = "redirect-queue-name"
+        tags {
+            tag1 = "tagged1"
+            tag2 = "tagged2"
+        }
     }
     queue1-dead-letters { }
     audit-queue-name { }

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ val jclOverSlf4j = "org.slf4j" % "jcl-over-slf4j" % "1.7.25" // needed form amaz
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
 val awaitility = "org.awaitility" % "awaitility-scala" % "3.1.1"
 
-val amazonJavaSdk = "com.amazonaws" % "aws-java-sdk" % "1.11.362" exclude ("commons-logging", "commons-logging")
+val amazonJavaSdk = "com.amazonaws" % "aws-java-sdk" % "1.11.376" exclude ("commons-logging", "commons-logging")
 
 val scalaGraph = "org.scala-graph" %% "graph-core" % "1.12.5"
 

--- a/common-test/src/main/scala/org/elasticmq/test/package.scala
+++ b/common-test/src/main/scala/org/elasticmq/test/package.scala
@@ -1,7 +1,8 @@
 package org.elasticmq
 
 import java.io.File
-import util.Random
+
+import scala.util.Random
 
 package object test {
   def timed(block: => Unit) = {
@@ -25,8 +26,8 @@ package object test {
     tempDir
   }
 
-  def deleteDirRecursively(dir: File) {
-    dir.listFiles().filter(_.isDirectory).foreach(deleteDirRecursively(_))
+  def deleteDirRecursively(dir: File): Unit = {
+    dir.listFiles().filter(_.isDirectory).foreach(deleteDirRecursively)
     dir.listFiles().filter(!_.isDirectory).foreach(_.delete())
     dir.delete()
   }

--- a/core/src/main/scala/org/elasticmq/QueueData.scala
+++ b/core/src/main/scala/org/elasticmq/QueueData.scala
@@ -12,6 +12,7 @@ case class QueueData(name: String,
                      isFifo: Boolean = false,
                      hasContentBasedDeduplication: Boolean = false,
                      copyMessagesTo: Option[String] = None,
-                     moveMessagesTo: Option[String] = None)
+                     moveMessagesTo: Option[String] = None,
+                     tags: Map[String, String] = Map[String, String]())
 
 case class DeadLettersQueueData(name: String, maxReceiveCount: Int)

--- a/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
+++ b/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
@@ -16,7 +16,7 @@ class QueueManagerActor(nowProvider: NowProvider) extends ReplyingActor with Log
   private val queues = collection.mutable.HashMap[String, ActorRef]()
 
   def receiveAndReply[T](msg: QueueManagerMsg[T]): ReplyAction[T] = msg match {
-    case CreateQueue(queueData) => {
+    case CreateQueue(queueData) =>
       if (queues.contains(queueData.name)) {
         logger.debug(s"Cannot create queue, as it already exists: $queueData")
         Left(new QueueAlreadyExists(queueData.name))
@@ -26,18 +26,15 @@ class QueueManagerActor(nowProvider: NowProvider) extends ReplyingActor with Log
         queues(queueData.name) = actor
         Right(actor)
       }
-    }
 
-    case DeleteQueue(queueName) => {
+    case DeleteQueue(queueName) =>
       logger.info(s"Deleting queue $queueName")
-      queues.remove(queueName).foreach(context.stop(_))
-    }
+      queues.remove(queueName).foreach(context.stop)
 
-    case LookupQueue(queueName) => {
+    case LookupQueue(queueName) =>
       val result = queues.get(queueName)
       logger.debug(s"Looking up queue $queueName, found?: ${result.isDefined}")
       result
-    }
 
     case ListQueues() => queues.keySet.toSeq
   }

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActor.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActor.scala
@@ -10,7 +10,7 @@ import scala.reflect._
 
 class QueueActor(val nowProvider: NowProvider,
                  val initialQueueData: QueueData,
-                 val deadLettersActorRef: Option[ActorRef] = None,
+                 var deadLettersActorRef: Option[ActorRef] = None,
                  val copyMessagesToActorRef: Option[ActorRef] = None,
                  val moveMessagesToActorRef: Option[ActorRef] = None)
     extends QueueActorStorage

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
@@ -161,7 +161,7 @@ trait QueueActorMessageOps extends Logging {
     case MillisVisibilityTimeout(millis) => millis
   }
 
-  private def deleteMessage(deliveryReceipt: DeliveryReceipt) {
+  private def deleteMessage(deliveryReceipt: DeliveryReceipt): Unit = {
     val msgId = deliveryReceipt.extractId.toString
 
     messageQueue.byId.get(msgId).foreach { msgData =>

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
@@ -142,7 +142,7 @@ trait QueueActorMessageOps extends Logging {
     messageQueue.dequeue(count, deliveryTime).flatMap { internalMessage =>
       if (queueData.deadLettersQueue.map(_.maxReceiveCount).exists(_ <= internalMessage.receiveCount)) {
         logger.debug(s"${queueData.name}: send message $internalMessage to dead letters actor $deadLettersActorRef")
-        deadLettersActorRef.foreach(_ ! SendMessage(internalMessage.toNewMessageData))
+        deadLettersQueueActor.foreach(_ ! SendMessage(internalMessage.toNewMessageData))
         internalMessage.deliveryReceipts.foreach(dr => deleteMessage(DeliveryReceipt(dr)))
         None
       } else {

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
@@ -142,7 +142,7 @@ trait QueueActorMessageOps extends Logging {
     messageQueue.dequeue(count, deliveryTime).flatMap { internalMessage =>
       if (queueData.deadLettersQueue.map(_.maxReceiveCount).exists(_ <= internalMessage.receiveCount)) {
         logger.debug(s"${queueData.name}: send message $internalMessage to dead letters actor $deadLettersActorRef")
-        deadLettersQueueActor.foreach(_ ! SendMessage(internalMessage.toNewMessageData))
+        deadLettersActorRef.foreach(_ ! SendMessage(internalMessage.toNewMessageData))
         internalMessage.deliveryReceipts.foreach(dr => deleteMessage(DeliveryReceipt(dr)))
         None
       } else {

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorQueueOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorQueueOps.scala
@@ -1,9 +1,9 @@
 package org.elasticmq.actor.queue
 
 import org.elasticmq._
+import org.elasticmq.actor.reply._
 import org.elasticmq.msg._
 import org.elasticmq.util.Logging
-import org.elasticmq.actor.reply._
 
 trait QueueActorQueueOps extends Logging {
   this: QueueActorStorage =>
@@ -19,9 +19,33 @@ trait QueueActorQueueOps extends Logging {
     case UpdateQueueReceiveMessageWait(newReceiveMessageWait) =>
       logger.info(s"${queueData.name}: Updating receive message wait to $newReceiveMessageWait")
       queueData = queueData.copy(receiveMessageWait = newReceiveMessageWait)
+    case UpdateQueueDeadLettersQueue(newDeadLettersQueue, newDeadLettersQueueActor) =>
+      if (newDeadLettersQueue.isDefined) {
+        logger.info(
+          s"${queueData.name}: Updating Dead Letters Queue to ${newDeadLettersQueue.get.name} with maxReceiveCount ${newDeadLettersQueue.get.maxReceiveCount}")
+      } else {
+        logger.info(s"${queueData.name}: Removing Dead Letters Queue")
+      }
+      queueData = queueData.copy(deadLettersQueue = newDeadLettersQueue)
+      deadLettersQueueActor = newDeadLettersQueueActor
     case ClearQueue() =>
+      logger.info(s"${queueData.name}: Clearing queue")
       messageQueue.clear()
     case GetQueueStatistics(deliveryTime) => getQueueStatistics(deliveryTime)
+    case UpdateQueueTags(newQueueTags) =>
+      logger.info(s"${queueData.name} Adding and Updating tags")
+      var tmpTags = queueData.tags
+      for ((k, v) <- newQueueTags) {
+        tmpTags += (k -> v)
+      }
+      queueData = queueData.copy(tags = tmpTags)
+    case RemoveQueueTags(tagsToRemove) =>
+      logger.info(s"${queueData.name} Removing tags")
+      var tmpTags = queueData.tags
+      for (tag <- tagsToRemove) {
+        tmpTags -= tag
+      }
+      queueData = queueData.copy(tags = tmpTags)
   }
 
   private def getQueueStatistics(deliveryTime: Long) = {

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorQueueOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorQueueOps.scala
@@ -38,12 +38,8 @@ trait QueueActorQueueOps extends Logging {
       messageQueue.clear()
     case GetQueueStatistics(deliveryTime) => getQueueStatistics(deliveryTime)
     case UpdateQueueTags(newQueueTags) =>
-      logger.info(s"${queueData.name} Adding and Updating tags")
-      var tmpTags = queueData.tags
-      for ((k, v) <- newQueueTags) {
-        tmpTags += (k -> v)
-      }
-      queueData = queueData.copy(tags = tmpTags)
+      logger.info(s"${queueData.name} Adding and Updating tags ${newQueueTags}")
+      queueData = queueData.copy(tags = queueData.tags ++ newQueueTags)
     case RemoveQueueTags(tagsToRemove) =>
       logger.info(s"${queueData.name} Removing tags")
       var tmpTags = queueData.tags

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
@@ -15,6 +15,6 @@ trait QueueActorStorage {
 
   var queueData: QueueData = initialQueueData
   var messageQueue = MessageQueue(queueData.isFifo)
-  val deadLettersQueueActor: Option[ActorRef] = deadLettersActorRef
+  var deadLettersQueueActor: Option[ActorRef] = deadLettersActorRef
   val receiveRequestAttemptCache = new ReceiveRequestAttemptCache
 }

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
@@ -9,12 +9,11 @@ trait QueueActorStorage {
 
   def initialQueueData: QueueData
 
-  def deadLettersActorRef: Option[ActorRef]
+  var deadLettersActorRef: Option[ActorRef]
   def copyMessagesToActorRef: Option[ActorRef]
   def moveMessagesToActorRef: Option[ActorRef]
 
   var queueData: QueueData = initialQueueData
   var messageQueue = MessageQueue(queueData.isFifo)
-  var deadLettersQueueActor: Option[ActorRef] = deadLettersActorRef
   val receiveRequestAttemptCache = new ReceiveRequestAttemptCache
 }

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorWaitForMessagesOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorWaitForMessagesOps.scala
@@ -18,13 +18,12 @@ trait QueueActorWaitForMessagesOps extends ReplyingActor with QueueActorMessageO
     new collection.mutable.HashMap[Long, AwaitingData]()
 
   override def receive = super.receive orElse {
-    case ReplyIfTimeout(seq, replyWith) => {
+    case ReplyIfTimeout(seq, replyWith) =>
       awaitingReply.remove(seq).foreach {
         case AwaitingData(originalSender, _, _) =>
           logger.debug(s"${queueData.name}: Awaiting messages: sequence $seq timed out. Replying with no messages.")
           originalSender ! replyWith
       }
-    }
 
     case TryReply =>
       scheduledTryReply = None
@@ -61,7 +60,7 @@ trait QueueActorWaitForMessagesOps extends ReplyingActor with QueueActorMessageO
   }
 
   @tailrec
-  private def tryReply() {
+  private def tryReply(): Unit = {
     awaitingReply.headOption match {
       case Some(
           (seq,
@@ -87,7 +86,7 @@ trait QueueActorWaitForMessagesOps extends ReplyingActor with QueueActorMessageO
     seq
   }
 
-  private def scheduleTimeoutReply(seq: Long, waitForMessages: Duration) {
+  private def scheduleTimeoutReply(seq: Long, waitForMessages: Duration): Unit = {
     schedule(waitForMessages.getMillis, ReplyIfTimeout(seq, Nil))
   }
 

--- a/core/src/main/scala/org/elasticmq/actor/reply/ReplyingActor.scala
+++ b/core/src/main/scala/org/elasticmq/actor/reply/ReplyingActor.scala
@@ -10,12 +10,11 @@ trait ReplyingActor extends Actor {
   val ev: ClassTag[M[Unit]]
 
   def receive = {
-    case m if ev.runtimeClass.isAssignableFrom(m.getClass) => {
+    case m if ev.runtimeClass.isAssignableFrom(m.getClass) =>
       doReceiveAndReply(m.asInstanceOf[M[Unit]])
-    }
   }
 
-  private def doReceiveAndReply[T](msg: M[T]) {
+  private def doReceiveAndReply[T](msg: M[T]): Unit = {
     try {
       receiveAndReply(msg) match {
         case ReplyWith(t) => sender ! t

--- a/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
+++ b/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
@@ -15,7 +15,10 @@ case class UpdateQueueDefaultVisibilityTimeout(newDefaultVisibilityTimeout: Mill
     extends QueueQueueMsg[Unit]
 case class UpdateQueueDelay(newDelay: Duration) extends QueueQueueMsg[Unit]
 case class UpdateQueueReceiveMessageWait(newReceiveMessageWait: Duration) extends QueueQueueMsg[Unit]
-case class UpdateQueueDeadLettersQueue(newDeadLettersQueue: Option[DeadLettersQueueData], newDeadLettersQueueActor: Option[ActorRef]) extends QueueQueueMsg[Unit]
+
+case class UpdateQueueDeadLettersQueue(newDeadLettersQueue: Option[DeadLettersQueueData],
+                                       newDeadLettersQueueActor: Option[ActorRef])
+    extends QueueQueueMsg[Unit]
 case class UpdateQueueTags(newQueueTags: Map[String, String]) extends QueueQueueMsg[Unit]
 case class RemoveQueueTags(tagsToRemove: List[String]) extends QueueQueueMsg[Unit]
 case class GetQueueStatistics(deliveryTime: Long) extends QueueQueueMsg[QueueStatistics]

--- a/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
+++ b/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
@@ -1,7 +1,8 @@
 package org.elasticmq.msg
 
-import org.elasticmq.actor.reply.Replyable
+import akka.actor.ActorRef
 import org.elasticmq._
+import org.elasticmq.actor.reply.Replyable
 import org.joda.time.Duration
 
 sealed trait QueueMsg[T] extends Replyable[T]
@@ -14,6 +15,9 @@ case class UpdateQueueDefaultVisibilityTimeout(newDefaultVisibilityTimeout: Mill
     extends QueueQueueMsg[Unit]
 case class UpdateQueueDelay(newDelay: Duration) extends QueueQueueMsg[Unit]
 case class UpdateQueueReceiveMessageWait(newReceiveMessageWait: Duration) extends QueueQueueMsg[Unit]
+case class UpdateQueueDeadLettersQueue(newDeadLettersQueue: Option[DeadLettersQueueData], newDeadLettersQueueActor: Option[ActorRef]) extends QueueQueueMsg[Unit]
+case class UpdateQueueTags(newQueueTags: Map[String, String]) extends QueueQueueMsg[Unit]
+case class RemoveQueueTags(tagsToRemove: List[String]) extends QueueQueueMsg[Unit]
 case class GetQueueStatistics(deliveryTime: Long) extends QueueQueueMsg[QueueStatistics]
 case class ClearQueue() extends QueueQueueMsg[Unit]
 

--- a/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
+++ b/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
@@ -15,7 +15,6 @@ case class UpdateQueueDefaultVisibilityTimeout(newDefaultVisibilityTimeout: Mill
     extends QueueQueueMsg[Unit]
 case class UpdateQueueDelay(newDelay: Duration) extends QueueQueueMsg[Unit]
 case class UpdateQueueReceiveMessageWait(newReceiveMessageWait: Duration) extends QueueQueueMsg[Unit]
-
 case class UpdateQueueDeadLettersQueue(newDeadLettersQueue: Option[DeadLettersQueueData],
                                        newDeadLettersQueueActor: Option[ActorRef])
     extends QueueQueueMsg[Unit]

--- a/core/src/test/scala/org/elasticmq/actor/QueueActorMsgOpsTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/QueueActorMsgOpsTest.scala
@@ -37,7 +37,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
       lookupResult <- queueActor ? LookupMessage(MessageId("xyz"))
     } yield {
       // Then
-      lookupResult.map(createNewMessageData(_)) should be(Some(message))
+      lookupResult.map(createNewMessageData) should be(Some(message))
     }
   }
 
@@ -56,7 +56,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
       lookupResult <- queueActor ? LookupMessage(MessageId("xyz"))
     } yield {
       // Then
-      lookupResult.map(createNewMessageData(_)) should be(Some(m))
+      lookupResult.map(createNewMessageData) should be(Some(m))
     }
   }
 
@@ -95,7 +95,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
     } yield {
       // Then
       withoutDeliveryReceipt(lookupResult.headOption)
-        .map(createNewMessageData(_)) should be(Some(m.copy(nextDelivery = MillisNextDelivery(101L))))
+        .map(createNewMessageData) should be(Some(m.copy(nextDelivery = MillisNextDelivery(101L))))
     }
   }
 
@@ -113,7 +113,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
       lookupResult <- queueActor ? LookupMessage(MessageId("xyz"))
     } yield {
       // Then
-      withoutDeliveryReceipt(lookupResult).map(createNewMessageData(_)) should be(
+      withoutDeliveryReceipt(lookupResult).map(createNewMessageData) should be(
         Some(m.copy(nextDelivery = MillisNextDelivery(101L))))
     }
   }
@@ -199,7 +199,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
       lookupResult <- queueActor ? LookupMessage(MessageId("xyz"))
     } yield {
       // Then
-      lookupResult.map(createNewMessageData(_)) should be(
+      lookupResult.map(createNewMessageData) should be(
         Some(createNewMessageData("xyz", "1234", Map(), MillisNextDelivery(150L))))
     }
   }
@@ -351,7 +351,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
                                                           Some(Duration.millis(1000L)),
                                                           None)
       _ <- {
-        Thread.sleep(500); nowProvider.mutableNowMillis.set(200L);
+        Thread.sleep(500); nowProvider.mutableNowMillis.set(200L)
         queueActor ? SendMessage(msg)
       }
 
@@ -422,7 +422,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
                                                            None)
 
       _ <- {
-        Thread.sleep(500); queueActor ? SendMessage(msg1);
+        Thread.sleep(500); queueActor ? SendMessage(msg1)
         queueActor ? SendMessage(msg2)
       }
 

--- a/core/src/test/scala/org/elasticmq/actor/test/ActorTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/test/ActorTest.scala
@@ -13,14 +13,14 @@ abstract class ActorTest extends TestKit(ActorSystem()) with FunSuiteLike with M
   implicit val timeout: Timeout = maxDuration
   implicit val ec = system.dispatcher
 
-  override protected def afterAll() {
+  override protected def afterAll(): Unit = {
     waitFor(system.terminate())
     super.afterAll()
   }
 
   def waitFor[T](f: Future[T]): T = Await.result(f, maxDuration)
 
-  def waitTest(testName: String)(body: => Future[_]) {
+  def waitTest(testName: String)(body: => Future[_]): Unit = {
     test(testName) {
       waitFor(body)
     }

--- a/core/src/test/scala/org/elasticmq/actor/test/DataCreationHelpers.scala
+++ b/core/src/test/scala/org/elasticmq/actor/test/DataCreationHelpers.scala
@@ -11,7 +11,8 @@ trait DataCreationHelpers {
       defaultVisibilityTimeout: MillisVisibilityTimeout,
       deadLettersQueue: Option[DeadLettersQueueData] = None,
       copyMessagesToQueue: Option[String] = None,
-      moveMessagesToQueue: Option[String] = None
+      moveMessagesToQueue: Option[String] = None,
+      tags: Map[String, String] = Map[String, String]()
   ) =
     QueueData(
       name = name,
@@ -22,7 +23,8 @@ trait DataCreationHelpers {
       lastModified = new DateTime(0),
       deadLettersQueue = deadLettersQueue,
       copyMessagesTo = copyMessagesToQueue,
-      moveMessagesTo = moveMessagesToQueue
+      moveMessagesTo = moveMessagesToQueue,
+      tags = tags
     )
 
   def createMessageData(id: String,

--- a/core/src/test/scala/org/elasticmq/actor/test/QueueManagerForEachTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/test/QueueManagerForEachTest.scala
@@ -1,9 +1,8 @@
 package org.elasticmq.actor.test
 
-import org.scalatest.{Suite, BeforeAndAfterEach}
-import akka.actor.{Props, ActorSystem, ActorRef}
+import akka.actor.{ActorRef, ActorSystem, Props}
 import org.elasticmq.actor.QueueManagerActor
-import org.elasticmq.util.NowProvider
+import org.scalatest.{BeforeAndAfterEach, Suite}
 
 trait QueueManagerForEachTest extends BeforeAndAfterEach {
   this: Suite =>
@@ -13,13 +12,13 @@ trait QueueManagerForEachTest extends BeforeAndAfterEach {
   var queueManagerActor: ActorRef = _
   var nowProvider: MutableNowProvider = _
 
-  override protected def beforeEach() {
+  override protected def beforeEach(): Unit = {
     super.beforeEach()
     nowProvider = new MutableNowProvider
     queueManagerActor = system.actorOf(Props(new QueueManagerActor(nowProvider)))
   }
 
-  override protected def afterEach() {
+  override protected def afterEach(): Unit = {
     system.stop(queueManagerActor)
     super.afterEach()
   }

--- a/performance-tests/src/test/scala/org/elasticmq/performance/LocalPerformanceTest.scala
+++ b/performance-tests/src/test/scala/org/elasticmq/performance/LocalPerformanceTest.scala
@@ -2,29 +2,23 @@ package org.elasticmq.performance
 
 import java.util.concurrent.TimeUnit
 
-import com.amazonaws.services.sqs.AmazonSQSClient
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.util.Timeout
 import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.sqs.AmazonSQSClient
 import com.amazonaws.services.sqs.model.{CreateQueueRequest, DeleteMessageRequest, ReceiveMessageRequest, SendMessageRequest}
+import org.elasticmq.{NewMessageData, QueueData, _}
+import org.elasticmq.actor.QueueManagerActor
+import org.elasticmq.actor.reply._
+import org.elasticmq.msg.{CreateQueue, ReceiveMessages, SendMessage, _}
 import org.elasticmq.rest.sqs.{SQSRestServer, SQSRestServerBuilder}
 import org.elasticmq.test._
+import org.elasticmq.util.NowProvider
+import org.joda.time.DateTime
 
 import scala.collection.JavaConversions._
-import akka.actor.{ActorRef, ActorSystem, Props}
-import org.elasticmq.actor.QueueManagerActor
-import org.elasticmq.util.NowProvider
-import org.elasticmq.actor.reply._
-import org.elasticmq.msg._
-import org.elasticmq._
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import org.joda.time.DateTime
-import org.elasticmq.msg.ReceiveMessages
-import org.elasticmq.QueueData
-import org.elasticmq.NewMessageData
-import org.elasticmq.msg.SendMessage
-import org.elasticmq.msg.CreateQueue
-import akka.util.Timeout
 
 object LocalPerformanceTest extends App {
   testAll()
@@ -38,12 +32,13 @@ object LocalPerformanceTest extends App {
     //testWithMq(new ActorBasedMQ, iterations, msgsInIteration, "in-memory", 1)
     //testWithMq(new ActorBasedMQ, iterations, msgsInIteration, "in-memory", 2)
     //testWithMq(new ActorBasedMQ, iterations, msgsInIteration, "in-memory", 3)
-    testWithMq(new RestSQSMQ, iterations, msgsInIteration,  "rest-sqs + in-memory", 1)
+    testWithMq(new RestSQSMQ, iterations, msgsInIteration, "rest-sqs + in-memory", 1)
   }
 
   def testWithMq(mq: MQ, iterations: Int, msgsInIteration: Int, name: String, threadCount: Int) {
-    println("Running test for [%s], iterations: %d, msgs in iteration: %d, thread count: %d."
-      .format(name, iterations, msgsInIteration, threadCount))
+    println(
+      "Running test for [%s], iterations: %d, msgs in iteration: %d, thread count: %d."
+        .format(name, iterations, msgsInIteration, threadCount))
 
     mq.start()
 
@@ -74,7 +69,7 @@ object LocalPerformanceTest extends App {
       val loopStart = System.currentTimeMillis()
 
       for (j <- 1 to msgsInIteration) {
-        mq.sendMessage("Message" + (i*j))
+        mq.sendMessage("Message" + (i * j))
       }
 
       for (j <- 1 to msgsInIteration) {
@@ -84,11 +79,70 @@ object LocalPerformanceTest extends App {
       count += msgsInIteration
 
       val loopEnd = System.currentTimeMillis()
-      println("%-20s throughput: %f, %d".format(name, (count.toDouble / ((loopEnd-start).toDouble / 1000.0)), (loopEnd - loopStart)))
+      println(
+        "%-20s throughput: %f, %d"
+          .format(name, (count.toDouble / ((loopEnd - start).toDouble / 1000.0)), (loopEnd - loopStart)))
     }
   }
 
   class ActorBasedMQ extends MQWithQueueManagerActor
+
+  trait MQWithQueueManagerActor extends MQ {
+    private var currentQueue: ActorRef = _
+
+    implicit val timeout = Timeout(10000L, TimeUnit.MILLISECONDS)
+
+    override def start() = {
+      val queueManagerActor = super.start()
+
+      currentQueue = Await
+        .result(
+          queueManagerActor ? CreateQueue(
+            QueueData("testQueue",
+              MillisVisibilityTimeout(1000),
+              org.joda.time.Duration.ZERO,
+              org.joda.time.Duration.ZERO,
+              new DateTime(),
+              new DateTime())),
+          10.seconds
+        )
+        .right
+        .get
+
+      queueManagerActor
+    }
+
+    def sendMessage(m: String) {
+      Await.result(currentQueue ? SendMessage(NewMessageData(None, m, Map.empty, ImmediateNextDelivery, None, None)),
+        10.seconds)
+    }
+
+    def receiveMessage() = {
+      val messages = Await.result(currentQueue ? ReceiveMessages(DefaultVisibilityTimeout, 1, None, None), 10.seconds)
+      val message = messages.head
+      Await.result(currentQueue ? DeleteMessage(message.deliveryReceipt.get), 10.seconds)
+      message.content
+    }
+  }
+
+  trait MQ {
+    var actorSystem: ActorSystem = _
+
+    def start(): ActorRef = {
+      actorSystem = ActorSystem("performance-tests")
+      val queueManagerActor = actorSystem.actorOf(Props(new QueueManagerActor(new NowProvider())))
+
+      queueManagerActor
+    }
+
+    def stop() {
+      actorSystem.terminate()
+    }
+
+    def sendMessage(m: String)
+
+    def receiveMessage(): String
+  }
 
   class RestSQSMQ extends MQ {
     private var currentSQSClient: AmazonSQSClient = _
@@ -105,8 +159,8 @@ object LocalPerformanceTest extends App {
 
       currentSQSClient = new AmazonSQSClient(new BasicAWSCredentials("x", "x"))
       currentSQSClient.setEndpoint("http://localhost:9324")
-      currentQueueUrl = currentSQSClient.createQueue(
-        new CreateQueueRequest("testQueue").withAttributes(Map("VisibilityTimeout" -> "1")))
+      currentQueueUrl = currentSQSClient
+        .createQueue(new CreateQueueRequest("testQueue").withAttributes(Map("VisibilityTimeout" -> "1")))
         .getQueueUrl
 
       queueManagerActor
@@ -131,51 +185,6 @@ object LocalPerformanceTest extends App {
       currentSQSClient.deleteMessage(new DeleteMessageRequest(currentQueueUrl, msgs.get(0).getReceiptHandle))
 
       msgs.get(0).getBody
-    }
-  }
-
-  trait MQ {
-    var actorSystem: ActorSystem = _
-
-    def start(): ActorRef = {
-      actorSystem = ActorSystem("performance-tests")
-      val queueManagerActor = actorSystem.actorOf(Props(new QueueManagerActor(new NowProvider())))
-
-      queueManagerActor
-    }
-
-    def stop() {
-      actorSystem.terminate()
-    }
-
-    def sendMessage(m: String)
-
-    def receiveMessage(): String
-  }
-
-  trait MQWithQueueManagerActor extends MQ {
-    private var currentQueue: ActorRef = _
-
-    implicit val timeout = Timeout(10000L, TimeUnit.MILLISECONDS)
-
-    override def start() = {
-      val queueManagerActor = super.start()
-
-      currentQueue = Await.result(queueManagerActor ? CreateQueue(QueueData("testQueue", MillisVisibilityTimeout(1000),
-       org.joda.time.Duration.ZERO, org.joda.time.Duration.ZERO, new DateTime(), new DateTime())), 10.seconds).right.get
-
-      queueManagerActor
-    }
-
-    def sendMessage(m: String) {
-      Await.result(currentQueue ? SendMessage(NewMessageData(None, m, Map.empty, ImmediateNextDelivery, None, None)), 10.seconds)
-    }
-
-    def receiveMessage() = {
-      val messages = Await.result(currentQueue ? ReceiveMessages(DefaultVisibilityTimeout, 1, None, None), 10.seconds)
-      val message = messages.head
-      Await.result(currentQueue ? DeleteMessage(message.deliveryReceipt.get), 10.seconds)
-      message.content
     }
   }
 }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/BatchRequestsModule.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/BatchRequestsModule.scala
@@ -67,7 +67,7 @@ object BatchRequestsModule {
           val subKey = keyMatch.group(2)
 
           val subMap =
-            subParameters.get(discriminator).getOrElse(Map[String, String]())
+            subParameters.getOrElse(discriminator, Map[String, String]())
           subParameters.put(discriminator, subMap + (subKey -> value))
         }
     }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
@@ -84,7 +84,7 @@ trait CreateQueueDirectives {
             if (!queueName.matches("[\\p{Alnum}\\._-]*")) {
               throw SQSException.invalidParameterValue
             } else if (sqsLimits == SQSLimits.Strict && queueName
-              .length() > 80) {
+                         .length() > 80) {
               throw SQSException.invalidParameterValue
             } else if (isFifo && !queueName.endsWith(".fifo")) {
               throw SQSException.invalidParameterValue
@@ -96,9 +96,9 @@ trait CreateQueueDirectives {
 
             // if the request set the attributes compare them against the queue
             if ((secondsDelayOpt.isDefined && queueData.delay.getStandardSeconds != secondsDelay) ||
-              (secondsReceiveMessageWaitTimeOpt.isDefined
+                (secondsReceiveMessageWaitTimeOpt.isDefined
                 && queueData.receiveMessageWait.getStandardSeconds != secondsReceiveMessageWaitTime) ||
-              (secondsVisibilityTimeoutOpt.isDefined
+                (secondsVisibilityTimeoutOpt.isDefined
                 && queueData.defaultVisibilityTimeout.seconds != secondsVisibilityTimeout)) {
               // Special case: the queue existed, but has different attributes
               throw new SQSException("AWS.SimpleQueueService.QueueNameExists")
@@ -108,14 +108,10 @@ trait CreateQueueDirectives {
               respondWith {
                 <CreateQueueResponse>
                   <CreateQueueResult>
-                    <QueueUrl>
-                      {url}
-                    </QueueUrl>
+                    <QueueUrl>{url}</QueueUrl>
                   </CreateQueueResult>
                   <ResponseMetadata>
-                    <RequestId>
-                      {EmptyRequestId}
-                    </RequestId>
+                    <RequestId>{EmptyRequestId}</RequestId>
                   </ResponseMetadata>
                 </CreateQueueResponse>
               }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
@@ -79,7 +79,6 @@ trait CreateQueueDirectives {
               isFifo,
               hasContentBasedDeduplication
             )
-            //TODO: add tags
 
             if (!queueName.matches("[\\p{Alnum}\\._-]*")) {
               throw SQSException.invalidParameterValue

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
@@ -77,9 +77,9 @@ trait CreateQueueDirectives {
               now,
               redrivePolicy.map(rd => DeadLettersQueueData(rd.queueName, rd.maxReceiveCount)),
               isFifo,
-              hasContentBasedDeduplication,
-              Map[String, String]()
+              hasContentBasedDeduplication
             )
+            //TODO: add tags
 
             if (!queueName.matches("[\\p{Alnum}\\._-]*")) {
               throw SQSException.invalidParameterValue

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -119,17 +119,14 @@ trait QueueAttributesDirectives {
         val result = attributes.map({
           case (attributeName, attributeValue) =>
             attributeName match {
-              case VisibilityTimeoutParameter => {
+              case VisibilityTimeoutParameter =>
                 queueActor ? UpdateQueueDefaultVisibilityTimeout(
                   MillisVisibilityTimeout.fromSeconds(attributeValue.toLong))
-              }
-              case DelaySecondsAttribute => {
+              case DelaySecondsAttribute =>
                 queueActor ? UpdateQueueDelay(Duration.standardSeconds(attributeValue.toLong))
-              }
-              case ReceiveMessageWaitTimeSecondsAttribute => {
+              case ReceiveMessageWaitTimeSecondsAttribute =>
                 queueActor ? UpdateQueueReceiveMessageWait(Duration.standardSeconds(attributeValue.toLong))
-              }
-              case RedrivePolicyParameter => {
+              case RedrivePolicyParameter =>
                 val redrivePolicy =
                   try {
                     import org.elasticmq.rest.sqs.model.RedrivePolicyJson._
@@ -155,13 +152,11 @@ trait QueueAttributesDirectives {
                     Some(DeadLettersQueueData(redrivePolicy.queueName, redrivePolicy.maxReceiveCount)),
                     deadLettersQueueActor)
                 }
-              }
               case attr
                   if UnsupportedAttributeNames.AllUnsupportedAttributeNames
-                    .contains(attr) => {
+                    .contains(attr) =>
                 logger.warn("Ignored attribute \"" + attr + "\" (supported by SQS but not ElasticMQ)")
                 Future.successful(())
-              }
               case _ => Future.failed(new SQSException("InvalidAttributeName"))
             }
         })

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -1,23 +1,21 @@
 package org.elasticmq.rest.sqs
 
-import org.elasticmq.MillisVisibilityTimeout
-import Constants._
-import org.joda.time.Duration
-import org.elasticmq.msg.{
-  GetQueueStatistics,
-  UpdateQueueDefaultVisibilityTimeout,
-  UpdateQueueDelay,
-  UpdateQueueReceiveMessageWait
-}
 import org.elasticmq.actor.reply._
-import scala.concurrent.Future
-
+import org.elasticmq.msg._
+import org.elasticmq.rest.sqs.Constants._
 import org.elasticmq.rest.sqs.directives.ElasticMQDirectives
 import org.elasticmq.rest.sqs.model.RedrivePolicy
+import org.elasticmq.{DeadLettersQueueData, MillisVisibilityTimeout}
+import org.joda.time.Duration
+import spray.json.JsonParser.ParsingException
 import spray.json._
+
+import scala.async.Async.{await, _}
+import scala.concurrent.Future
 
 trait QueueAttributesDirectives {
   this: ElasticMQDirectives with AttributesModule =>
+
   object QueueWriteableAttributeNames {
     val AllWriteableAttributeNames = VisibilityTimeoutParameter :: DelaySecondsAttribute ::
       ReceiveMessageWaitTimeSecondsAttribute :: RedrivePolicyParameter :: Nil
@@ -27,10 +25,9 @@ trait QueueAttributesDirectives {
     val PolicyAttribute = "Policy"
     val MaximumMessageSizeAttribute = "MaximumMessageSize"
     val MessageRetentionPeriodAttribute = "MessageRetentionPeriod"
-    val RedrivePolicyAttribute = "RedrivePolicy"
 
     val AllUnsupportedAttributeNames = PolicyAttribute :: MaximumMessageSizeAttribute ::
-      MessageRetentionPeriodAttribute :: RedrivePolicyAttribute :: Nil
+      MessageRetentionPeriodAttribute :: Nil
   }
 
   object QueueReadableAttributeNames {
@@ -96,7 +93,9 @@ trait QueueAttributesDirectives {
               {attributesToXmlConverter.convert(attributes)}
             </GetQueueAttributesResult>
             <ResponseMetadata>
-              <RequestId>{EmptyRequestId}</RequestId>
+              <RequestId>
+                {EmptyRequestId}
+              </RequestId>
             </ResponseMetadata>
           </GetQueueAttributesResponse>
         }
@@ -132,6 +131,32 @@ trait QueueAttributesDirectives {
               case ReceiveMessageWaitTimeSecondsAttribute => {
                 queueActor ? UpdateQueueReceiveMessageWait(Duration.standardSeconds(attributeValue.toLong))
               }
+              case RedrivePolicyParameter => {
+                val redrivePolicy =
+                  try {
+                    import org.elasticmq.rest.sqs.model.RedrivePolicyJson._
+                    attributeValue.parseJson.convertTo[RedrivePolicy]
+                  } catch {
+                    case e: DeserializationException =>
+                      logger.warn("Cannot deserialize the redrive policy attribute", e)
+                      throw new SQSException("MalformedQueryString")
+                    case e: ParsingException =>
+                      logger.warn("Cannot parse the redrive policy attribute", e)
+                      throw new SQSException("MalformedQueryString")
+                  }
+                async {
+                  val deadLettersQueueActor = await(queueManagerActor ? LookupQueue(redrivePolicy.queueName))
+                  if (deadLettersQueueActor.isEmpty) {
+                    throw SQSException.nonExistentQueue
+                  }
+
+                  if (redrivePolicy.maxReceiveCount < 1 || redrivePolicy.maxReceiveCount > 1000) {
+                    throw SQSException.invalidParameterValue
+                  }
+                  queueActor ? UpdateQueueDeadLettersQueue(
+                    Some(DeadLettersQueueData(redrivePolicy.queueName, redrivePolicy.maxReceiveCount)), deadLettersQueueActor)
+                }
+              }
               case attr
                   if UnsupportedAttributeNames.AllUnsupportedAttributeNames
                     .contains(attr) => {
@@ -146,7 +171,9 @@ trait QueueAttributesDirectives {
           respondWith {
             <SetQueueAttributesResponse>
               <ResponseMetadata>
-                <RequestId>{EmptyRequestId}</RequestId>
+                <RequestId>
+                  {EmptyRequestId}
+                </RequestId>
               </ResponseMetadata>
             </SetQueueAttributesResponse>
           }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -93,9 +93,7 @@ trait QueueAttributesDirectives {
               {attributesToXmlConverter.convert(attributes)}
             </GetQueueAttributesResult>
             <ResponseMetadata>
-              <RequestId>
-                {EmptyRequestId}
-              </RequestId>
+              <RequestId>{EmptyRequestId}</RequestId>
             </ResponseMetadata>
           </GetQueueAttributesResponse>
         }
@@ -154,7 +152,8 @@ trait QueueAttributesDirectives {
                     throw SQSException.invalidParameterValue
                   }
                   queueActor ? UpdateQueueDeadLettersQueue(
-                    Some(DeadLettersQueueData(redrivePolicy.queueName, redrivePolicy.maxReceiveCount)), deadLettersQueueActor)
+                    Some(DeadLettersQueueData(redrivePolicy.queueName, redrivePolicy.maxReceiveCount)),
+                    deadLettersQueueActor)
                 }
               }
               case attr
@@ -171,9 +170,7 @@ trait QueueAttributesDirectives {
           respondWith {
             <SetQueueAttributesResponse>
               <ResponseMetadata>
-                <RequestId>
-                  {EmptyRequestId}
-                </RequestId>
+                <RequestId>{EmptyRequestId}</RequestId>
               </ResponseMetadata>
             </SetQueueAttributesResponse>
           }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
@@ -119,7 +119,7 @@ trait ReceiveMessageDirectives {
                   <MD5OfBody>{md5Digest(msg.content)}</MD5OfBody>
                   <Body>{XmlUtil.convertTexWithCRToNodeSeq(msg.content)}</Body>
                   {attributesToXmlConverter.convert(calculateAttributeValues(msg))}
-                  {if (!filteredMessageAttributes.isEmpty) <MD5OfMessageAttributes>{md5AttributeDigest(filteredMessageAttributes)}</MD5OfMessageAttributes>}
+                  {if (filteredMessageAttributes.nonEmpty) <MD5OfMessageAttributes>{md5AttributeDigest(filteredMessageAttributes)}</MD5OfMessageAttributes>}
                   {messageAttributesToXmlConverter.convert(filteredMessageAttributes.toList)}
                 </Message> }}
               </ReceiveMessageResult>

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageBatchDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageBatchDirectives.scala
@@ -40,7 +40,7 @@ trait SendMessageBatchDirectives {
     }
   }
 
-  def verifyMessagesNotTooLong(parameters: Map[String, String]) {
+  def verifyMessagesNotTooLong(parameters: Map[String, String]): Unit = {
     val messageLengths = for {
       parameterMap <- batchParametersMap(SendMessageBatchPrefix, parameters)
     } yield {

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
@@ -48,13 +48,12 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
     // Determine number of attributes -- there are likely ways to improve this
     val numAttributes = parameters
       .map {
-        case (k, v) => {
+        case (k, v) =>
           if (k.startsWith("MessageAttribute.")) {
             k.split("\\.")(1).toInt
           } else {
             0
           }
-        }
       }
       .toList
       .union(List(0))
@@ -72,21 +71,17 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
       }
 
       val value = primaryDataType match {
-        case "String" => {
+        case "String" =>
           StringMessageAttribute(parameters("MessageAttribute." + i + ".Value.StringValue"), customDataType)
-        }
-        case "Number" => {
+        case "Number" =>
           val strValue =
             parameters("MessageAttribute." + i + ".Value.StringValue")
           verifyMessageNumberAttribute(strValue)
           NumberMessageAttribute(strValue, customDataType)
-        }
-        case "Binary" => {
+        case "Binary" =>
           BinaryMessageAttribute.fromBase64(parameters("MessageAttribute." + i + ".Value.BinaryValue"), customDataType)
-        }
-        case _ => {
+        case _ =>
           throw new Exception("Currently only handles String, Number and Binary typed attributes")
-        }
       }
 
       (name, value)
@@ -155,7 +150,7 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
     } yield (message, digest, messageAttributeDigest)
   }
 
-  def verifyMessageNotTooLong(messageLength: Int) {
+  def verifyMessageNotTooLong(messageLength: Int): Unit = {
     ifStrictLimits(messageLength > 262144) {
       "MessageTooLong"
     }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/TagQueueDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/TagQueueDirectives.scala
@@ -11,18 +11,13 @@ trait TagQueueDirectives {
   def listQueueTags(p: AnyParams) = {
     p.action("ListQueueTags") {
       queueActorAndDataFromRequest(p) { (queueActor, queueData) =>
-        for ((k, v) <- queueData.tags) {
-          println(s"found $k,$v")
-        }
         respondWith {
           <ListQueueTagsResponse>
             <ListQueueTagsResult>
               {tagsToXmlConverter.convert(queueData.tags)}
             </ListQueueTagsResult>
             <ResponseMetadata>
-              <RequestId>
-                {EmptyRequestId}
-              </RequestId>
+              <RequestId>{EmptyRequestId}</RequestId>
             </ResponseMetadata>
           </ListQueueTagsResponse>
         }
@@ -38,9 +33,7 @@ trait TagQueueDirectives {
         respondWith {
           <UntagQueueResponse>
             <ResponseMetadata>
-              <RequestId>
-                {EmptyRequestId}
-              </RequestId>
+              <RequestId>{EmptyRequestId}</RequestId>
             </ResponseMetadata>
           </UntagQueueResponse>
         }
@@ -56,9 +49,7 @@ trait TagQueueDirectives {
         respondWith(
           <TagQueueResponse>
             <ResponseMetadata>
-              <RequestId>
-                {EmptyRequestId}
-              </RequestId>
+              <RequestId>{EmptyRequestId}</RequestId>
             </ResponseMetadata>
           </TagQueueResponse>
         )

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/TagQueueDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/TagQueueDirectives.scala
@@ -1,0 +1,68 @@
+package org.elasticmq.rest.sqs
+
+import org.elasticmq.actor.reply._
+import org.elasticmq.msg._
+import org.elasticmq.rest.sqs.Constants._
+import org.elasticmq.rest.sqs.directives.ElasticMQDirectives
+
+trait TagQueueDirectives {
+  this: ElasticMQDirectives with TagsModule =>
+
+  def listQueueTags(p: AnyParams) = {
+    p.action("ListQueueTags") {
+      queueActorAndDataFromRequest(p) { (queueActor, queueData) =>
+        for ((k, v) <- queueData.tags) {
+          println(s"found $k,$v")
+        }
+        respondWith {
+          <ListQueueTagsResponse>
+            <ListQueueTagsResult>
+              {tagsToXmlConverter.convert(queueData.tags)}
+            </ListQueueTagsResult>
+            <ResponseMetadata>
+              <RequestId>
+                {EmptyRequestId}
+              </RequestId>
+            </ResponseMetadata>
+          </ListQueueTagsResponse>
+        }
+      }
+    }
+  }
+
+  def untagQueue(p: AnyParams) = {
+    p.action("UntagQueue") {
+      queueActorFromRequest(p) { queueActor =>
+        val tags = tagNamesReader.read(p)
+        queueActor ? RemoveQueueTags(tags)
+        respondWith {
+          <UntagQueueResponse>
+            <ResponseMetadata>
+              <RequestId>
+                {EmptyRequestId}
+              </RequestId>
+            </ResponseMetadata>
+          </UntagQueueResponse>
+        }
+      }
+    }
+  }
+
+  def tagQueue(p: AnyParams) = {
+    p.action("TagQueue") {
+      queueActorFromRequest(p) { queueActor =>
+        val tags = tagNameAndValuesReader.read(p)
+        queueActor ? UpdateQueueTags(tags)
+        respondWith(
+          <TagQueueResponse>
+            <ResponseMetadata>
+              <RequestId>
+                {EmptyRequestId}
+              </RequestId>
+            </ResponseMetadata>
+          </TagQueueResponse>
+        )
+      }
+    }
+  }
+}

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/TagsModule.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/TagsModule.scala
@@ -7,11 +7,16 @@ trait TagsModule {
 
   class TagNameAndValuesReader {
     def read(parameters: Map[String, String]): Map[String, String] = {
+      // Fix for buggy Java library that sends "Tags" instead of "Tag" as per API specification
+      var tagPrefix = "Tag."
+      if (parameters.keySet.contains("Tags.1.Key")) {
+        tagPrefix = "Tags."
+      }
       def collect(suffix: Int, acc: Map[String, String]): Map[String, String] = {
-        parameters.get("Tag." + suffix + ".Key") match {
+        parameters.get(tagPrefix + suffix + ".Key") match {
           case None => acc
           case Some(an) =>
-            collect(suffix + 1, acc + (an -> parameters("Tag." + suffix + ".Value")))
+            collect(suffix + 1, acc + (an -> parameters(tagPrefix + suffix + ".Value")))
         }
       }
 

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/TagsModule.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/TagsModule.scala
@@ -1,0 +1,43 @@
+package org.elasticmq.rest.sqs
+
+trait TagsModule {
+  val tagNameAndValuesReader = new TagNameAndValuesReader
+  val tagNamesReader = new TagNamesReader
+  val tagsToXmlConverter = new TagsToXmlConverter
+
+  class TagNameAndValuesReader {
+    def read(parameters: Map[String, String]): Map[String, String] = {
+      def collect(suffix: Int, acc: Map[String, String]): Map[String, String] = {
+        parameters.get("Tag." + suffix + ".Key") match {
+          case None => acc
+          case Some(an) =>
+            collect(suffix + 1, acc + (an -> parameters("Tag." + suffix + ".Value")))
+        }
+      }
+
+      collect(1, Map())
+    }
+  }
+
+  class TagNamesReader {
+    def read(parameters: Map[String, String]): List[String] = {
+      def collect(suffix: Int, acc: List[String]): List[String] = {
+        parameters.get("TagKey." + suffix) match {
+          case None     => acc
+          case Some(an) => collect(suffix + 1, an :: acc)
+        }
+      }
+
+      collect(1, parameters.get("TagKey").toList)
+    }
+  }
+
+  class TagsToXmlConverter {
+    def convert(tags: Map[String, String]) = {
+      tags.map(t => <Tag>
+        <Key>{t._1}</Key>
+        <Value>{t._2}</Value>
+      </Tag>)
+    }
+  }
+}

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/RejectionDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/RejectionDirectives.scala
@@ -8,11 +8,10 @@ trait RejectionDirectives {
 
   val rejectionHandler = RejectionHandler
     .newBuilder()
-    .handleAll[Rejection] {
-      case rejections =>
-        handleServerExceptions { _ =>
-          throw new SQSException("Invalid request: " + rejections.map(_.toString).mkString(", "))
-        }
+    .handleAll[Rejection] { rejections =>
+      handleServerExceptions { _ =>
+        throw new SQSException("Invalid request: " + rejections.map(_.toString).mkString(", "))
+      }
     }
     .result()
 

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -39,5 +39,9 @@ queues {
     //      }
     //      copyTo = "audit-queue-name"
     //      moveTo = "redirect-queue-name
+    //      tags {
+    //        tag1 = "tagged1",
+    //        tag2 = "tagged2"
+    //      }
     //   }
 }

--- a/server/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
+++ b/server/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
@@ -22,11 +22,10 @@ class ElasticMQServer(config: ElasticMQServerConfig) extends Logging {
 
     createQueues(queueManagerActor)
 
-    () =>
-      {
-        restServerOpt.map(_.stopAndGetFuture())
-        Await.result(actorSystem.terminate(), Inf)
-      }
+    () => {
+      restServerOpt.map(_.stopAndGetFuture())
+      Await.result(actorSystem.terminate(), Inf)
+    }
   }
 
   private def createBase(): ActorRef = {
@@ -84,7 +83,8 @@ class ElasticMQServer(config: ElasticMQServerConfig) extends Logging {
       isFifo = cq.isFifo,
       hasContentBasedDeduplication = cq.hasContentBasedDeduplication,
       copyMessagesTo = cq.copyMessagesTo,
-      moveMessagesTo = cq.moveMessagesTo
+      moveMessagesTo = cq.moveMessagesTo,
+      Map[String, String]()
     )
   }
 

--- a/server/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
+++ b/server/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
@@ -85,7 +85,7 @@ class ElasticMQServer(config: ElasticMQServerConfig) extends Logging {
       hasContentBasedDeduplication = cq.hasContentBasedDeduplication,
       copyMessagesTo = cq.copyMessagesTo,
       moveMessagesTo = cq.moveMessagesTo,
-      Map[String, String]()
+      tags = cq.tags
     )
   }
 

--- a/server/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
+++ b/server/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
@@ -22,10 +22,11 @@ class ElasticMQServer(config: ElasticMQServerConfig) extends Logging {
 
     createQueues(queueManagerActor)
 
-    () => {
-      restServerOpt.map(_.stopAndGetFuture())
-      Await.result(actorSystem.terminate(), Inf)
-    }
+    () =>
+      {
+        restServerOpt.map(_.stopAndGetFuture())
+        Await.result(actorSystem.terminate(), Inf)
+      }
   }
 
   private def createBase(): ActorRef = {

--- a/server/src/main/scala/org/elasticmq/server/Main.scala
+++ b/server/src/main/scala/org/elasticmq/server/Main.scala
@@ -1,14 +1,14 @@
 package org.elasticmq.server
 
 import akka.actor.Terminated
-import org.elasticmq.util.Logging
-
-import io.Source
 import com.typesafe.config.ConfigFactory
 import org.elasticmq.server.config.ElasticMQServerConfig
+import org.elasticmq.util.Logging
+
+import scala.io.Source
 
 object Main extends Logging {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val start = System.currentTimeMillis()
     val version = readVersion()
     logger.info("Starting ElasticMQ server (%s) ...".format(version))
@@ -29,17 +29,15 @@ object Main extends Logging {
     Source.fromInputStream(stream).getLines().next()
   }
 
-  private def logUncaughtExceptions() {
-    Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
-      def uncaughtException(t: Thread, e: Throwable) {
-        logger.error("Uncaught exception in thread: " + t.getName, e)
-      }
+  private def logUncaughtExceptions(): Unit = {
+    Thread.setDefaultUncaughtExceptionHandler((t: Thread, e: Throwable) => {
+      logger.error("Uncaught exception in thread: " + t.getName, e)
     })
   }
 
-  private def addShutdownHook(shutdown: () => Terminated) {
+  private def addShutdownHook(shutdown: () => Terminated): Unit = {
     Runtime.getRuntime.addShutdownHook(new Thread() {
-      override def run() {
+      override def run(): Unit = {
         logger.info("ElasticMQ server stopping ...")
         shutdown()
         logger.info("=== ElasticMQ server stopped ===")

--- a/server/src/main/scala/org/elasticmq/server/config/CreateQueue.scala
+++ b/server/src/main/scala/org/elasticmq/server/config/CreateQueue.scala
@@ -8,4 +8,5 @@ case class CreateQueue(name: String,
                        isFifo: Boolean,
                        hasContentBasedDeduplication: Boolean,
                        copyMessagesTo: Option[String] = None,
-                       moveMessagesTo: Option[String] = None)
+                       moveMessagesTo: Option[String] = None,
+                       tags: Map[String, String] = Map[String, String]())

--- a/server/src/main/scala/org/elasticmq/server/config/ElasticMQServerConfig.scala
+++ b/server/src/main/scala/org/elasticmq/server/config/ElasticMQServerConfig.scala
@@ -66,6 +66,10 @@ class ElasticMQServerConfig(config: Config) extends Logging {
 
     import scala.collection.JavaConverters._
 
+    def getOptionalTags(c: Config, k: String): Map[String, String] =
+      if (c.hasPath(k)) c.getObject(k).asScala.map { case (key, _) => key -> c.getString(k + '.' + key) }.toMap
+      else Map[String, String]()
+
     val deadLettersQueueKey = "deadLettersQueue"
 
     val unsortedCreateQueues = config
@@ -89,7 +93,8 @@ class ElasticMQServerConfig(config: Config) extends Logging {
             isFifo = getOptionalBoolean(c, "fifo").getOrElse(false),
             hasContentBasedDeduplication = getOptionalBoolean(c, "contentBasedDeduplication").getOrElse(false),
             copyMessagesTo = getOptionalString(c, "copyTo"),
-            moveMessagesTo = getOptionalString(c, "moveTo")
+            moveMessagesTo = getOptionalString(c, "moveTo"),
+            tags = getOptionalTags(c, "tags")
           )
       }
       .toList

--- a/server/src/main/scala/org/elasticmq/server/config/ElasticMQServerConfig.scala
+++ b/server/src/main/scala/org/elasticmq/server/config/ElasticMQServerConfig.scala
@@ -64,12 +64,13 @@ class ElasticMQServerConfig(config: Config) extends Logging {
     def getOptionalDuration(c: Config, k: String) = if (c.hasPath(k)) Some(c.getDuration(k, TimeUnit.SECONDS)) else None
     def getOptionalString(c: Config, k: String) = if (c.hasPath(k)) Some(c.getString(k)).filter(_.nonEmpty) else None
 
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
 
     val deadLettersQueueKey = "deadLettersQueue"
 
     val unsortedCreateQueues = config
       .getObject("queues")
+      .asScala
       .map {
         case (n, v) =>
           val c = v.asInstanceOf[ConfigObject].toConfig

--- a/server/src/test/resources/test.conf
+++ b/server/src/test/resources/test.conf
@@ -69,9 +69,9 @@ queues {
   }
 
   queueWithTags {
-    tags: {
-      "tag1": "tagged1",
-      "tag2": "tagged2"
+    tags {
+      "tag1" = "tagged1"
+      "tag2" = "tagged2"
     }
   }
 }

--- a/server/src/test/resources/test.conf
+++ b/server/src/test/resources/test.conf
@@ -67,4 +67,11 @@ queues {
   queueWithRedirect {
     moveTo = "redirectToQueue"
   }
+
+  queueWithTags {
+    tags: {
+      "tag1": "tagged1",
+      "tag2": "tagged2"
+    }
+  }
 }

--- a/server/src/test/scala/org/elasticmq/server/config/ElasticMQServerConfigTest.scala
+++ b/server/src/test/scala/org/elasticmq/server/config/ElasticMQServerConfigTest.scala
@@ -11,12 +11,17 @@ class ElasticMQServerConfigTest extends FunSuite with Matchers {
 
   test("load the test config") {
     val conf = new ElasticMQServerConfig(ConfigFactory.load("test"))
-    conf.createQueues should have size 7
+    conf.createQueues should have size 8
     conf.createQueues.find(_.deadLettersQueue.isDefined).flatMap(_.deadLettersQueue).map(_.name) should be(
       Some("myDLQ"))
     conf.createQueues.find(_.copyMessagesTo.isDefined).flatMap(_.copyMessagesTo) should be(Some("auditQueue"))
     conf.createQueues.find(_.moveMessagesTo.isDefined).flatMap(_.moveMessagesTo) should be(Some("redirectToQueue"))
     val fifoQueue = conf.createQueues.find(_.isFifo).get
     fifoQueue.hasContentBasedDeduplication should be(true)
+    val taggedQueue = conf.createQueues.find(_.tags.nonEmpty).get
+    taggedQueue.tags should contain key "tag1"
+    taggedQueue.tags should contain value "tagged1"
+    taggedQueue.tags should contain key "tag2"
+    taggedQueue.tags should contain value "tagged2"
   }
 }


### PR DESCRIPTION
I've altered the DLQ behaviour to be more in line with the AWS SQS specification so that a dead letter queue can be added after a queue has been created.

Alongside this I've added support for tagging in a similar fashion to AWS SQS, allowing freeform tags in a String,String format.

This should address #69 and #132 