### PR TITLE
Implement terraform support via localstack

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/QueueAttributesDirectives.scala
@@ -30,11 +30,11 @@ trait QueueAttributesDirectives {
       MessageRetentionPeriodAttribute :: Nil
   }
 
-  object MockedFifoAttributeNames {
+  object FifoAttributeNames {
     val ContentBasedDeduplication = "ContentBasedDeduplication"
     val FifoQueue = "FifoQueue"
 
-    val AllMockedFifoAttributeNames = Seq(
+    val AllFifoAttributeNames = Seq(
       ContentBasedDeduplication,
       FifoQueue
     )
@@ -55,7 +55,7 @@ trait QueueAttributesDirectives {
         ApproximateNumberOfMessagesDelayedAttribute ::
         CreatedTimestampAttribute ::
         LastModifiedTimestampAttribute ::
-        QueueArnAttribute :: Nil) ++ MockedFifoAttributeNames.AllMockedFifoAttributeNames
+        QueueArnAttribute :: Nil) ++ FifoAttributeNames.AllFifoAttributeNames
   }
 
   def getQueueAttributes(p: AnyParams) = {
@@ -96,9 +96,9 @@ trait QueueAttributesDirectives {
           val fifoRules = queueData.isFifo match {
             case true => {
               Seq(
-                Rule(MockedFifoAttributeNames.FifoQueue, () => Future.successful(queueData.isFifo.toString())),
+                Rule(FifoAttributeNames.FifoQueue, () => Future.successful(queueData.isFifo.toString())),
                 Rule(
-                  MockedFifoAttributeNames.ContentBasedDeduplication,
+                  FifoAttributeNames.ContentBasedDeduplication,
                   () => Future.successful(queueData.hasContentBasedDeduplication.toString())
                 )
               )
@@ -182,7 +182,7 @@ trait QueueAttributesDirectives {
                 Future.successful(())
               }
               case attr
-                  if MockedFifoAttributeNames.AllMockedFifoAttributeNames
+                  if FifoAttributeNames.AllFifoAttributeNames
                     .contains(attr) => {
                 logger.info("Ignored attribute \"" + attr + "\" (handled separately by ElasticMQ)")
                 Future.successful(())


### PR DESCRIPTION
**Description**

I am trying to create resources on elasticmq using terraform.

My `main.tf`:

```tf
provider "aws" {
  region                      = "us-east-1"
  access_key                  = "anaccesskey"
  secret_key                  = "asecretkey"
  skip_credentials_validation = true
  skip_metadata_api_check     = true
  s3_force_path_style         = true

  endpoints {
    sqs      = "http://localhost:9324"
  }
}

resource "aws_sqs_queue" "terraform_queue_mq" {
  name                        = "terraform-queue-mq.fifo"
  fifo_queue                  = true
  content_based_deduplication = true
}

resource "aws_sqs_queue" "terraform_queue" {
  name                        = "my-queue"
}
```

Then running:

```bash
terraform init -input=false
terraform plan -input=false
terraform apply -input=false -auto-approve
```

I got:

```
Error: Error applying plan:

1 error(s) occurred:

* aws_sqs_queue.terraform_queue_mq: 1 error(s) occurred:

* aws_sqs_queue.terraform_queue_mq: [ERR] Error updating SQS attributes: InvalidAttributeName: InvalidAttributeName; see the SQS docs.
	status code: 400, request id: 00000000-0000-0000-0000-000000000000

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```